### PR TITLE
fix: bugfix http urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the [Singular](https://www.singular.net/) integration f
 
     ```
     repositories {
-        maven { url "http://maven.singular.net"}
+        maven { url "https://maven.singular.net"}
         ...
     }
     ```
@@ -25,8 +25,8 @@ This repository contains the [Singular](https://www.singular.net/) integration f
 
 ### Documentation
 
-[Singular integration](http://docs.mparticle.com/?java#singular)
+[Singular integration](https://docs.mparticle.com/?java#singular)
 
 ### License
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.mparticle.kit'
 
 repositories {
     maven {
-        url 'http://maven.singular.net'
+        url 'https://maven.singular.net'
     }
 }
 


### PR DESCRIPTION
## Summary
Updated `http://` urls to `https://` blocking lint in AGP 7.X upgrade

## Testing Plan
Check if any other `http://` references exist to upgrade