### PR TITLE
feat: Bumps Singular android native underlying SDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.singular.sdk:singular_sdk:12.5.4'
+    api 'com.singular.sdk:singular_sdk:12.6.0'
 
     androidTestImplementation 'androidx.test:runner:1.5.2'
     testImplementation 'org.powermock:powermock-core:2.0.9'


### PR DESCRIPTION
 ## Summary
 - Upgrade Singular Native Android SDK to 12.6.0

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
ran a local session with Singular's published native sdk

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
